### PR TITLE
Feature/logging levels

### DIFF
--- a/src/StateMachine/Modules/Logger.luau
+++ b/src/StateMachine/Modules/Logger.luau
@@ -17,13 +17,14 @@
 
 	Usage:
 		local Logger = require(path.to.Logger)
-		local logger = Logger.new("ModuleName")
+		local logger = Logger.new("ModuleName", Logger.LogLevel.Info)
 		logger:addDefaultHandler()
 		logger:addHandler(Logger.LogLevel.Error, function(level, name, ...)
 			-- Custom error handling that runs before the default handler, and prevents the default handler from handling this
+			print("Custom error handler:", name, level, ...)
 			return Logger.HandlerResult.Sink
 		end)
-		logger:debug("This is a debug message")
+		logger:debug("This is a debug message") -- Doesn't get handled because logger level is set to Info
 		logger:info("This is an info message")
 		logger:warning("This is a warning message")
 		logger:error("This is an error message")

--- a/src/StateMachine/Modules/Logger.luau
+++ b/src/StateMachine/Modules/Logger.luau
@@ -30,7 +30,9 @@
 		logger:error("This is an error message")
 		logger:assert(false, "This is an assertion error")
 
-	
+	A primary purpose of this class existing is to be able to check for errors from within tests. The StateMachine queues events,
+	starting a new thread to process them, which means errors that occur are not propagated to the main thread and can't be tested for.
+	This logger class allows for the testing of errors by adding a handler for errors, and then checking for those errors in tests.
 --]]
 
 export type LogLevel = "Error" | "Warning" | "Info" | "Debug"

--- a/src/StateMachine/Modules/Logger.luau
+++ b/src/StateMachine/Modules/Logger.luau
@@ -1,82 +1,85 @@
 --!strict
 
 --[[
-	TODO: Finish writing header comment and generally document the behavior of this logger
 	A lightweight, strongly-typed logger class designed with a minimal set of requirements for the StateMachine project, so it is not feature rich.
-	This logger class includes a few features such as different log levels (Debug, Info, Warning, Error), handler results (Sink, Continue), and the ability to add handlers.
-	It also provides methods for logging at different levels, and an assert method for condition checking where failing the assertion is automatically passed to the appropriate handler.
+	This logger class includes a few features such:
+	- A concept of log levels (Debug, Info, Warning, Error): These levels allow for categorizing the importance of the logs.
+	- Methods for logging at these levels: Convenient methods for logging at each level.
+	- The ability to add handlers: Handlers are functions that process logs. They can be added to the logger to customize its behavior.
+	- Handler results (Sink, Continue): Handlers return a result which determines if the logger should proceed with processing the log in other handlers.
+	- An assert method: Checks a condition, where failing the assertion invokes the appropriate handlers.
 
-	Handlers are processed in the opposite order they are added (LIFO). If a handler returns 'Sink', no other handlers will be invoked for that record.
+	Handlers are processed from highest minimum level to lowest minimum level. Within a level, they are processed in the
+	opposite order that they are added (LIFO). If a handler returns 'Sink', no other handlers will be invoked for that record.
 
 	Adding a default handler pipes non-erroneous records to output via print or warn depending on level,
 	and processes errors by throwing them, which will halt the execution of the program unless caught by an error handling mechanism.
 
 	Usage:
-	local logger = Logger.new("name")
-	logger:addHandler(level, handler)
-	logger:log(level, ...)
-	logger:debug(...)
-	logger:info(...)
-	logger:warning(...)
-	logger:error(...)
-	logger:assert(condition, message, level)
+		local Logger = require(path.to.Logger)
+		local logger = Logger.new("ModuleName")
+		logger:addDefaultHandler()
+		logger:addHandler(Logger.LogLevel.Error, function(level, name, ...)
+			-- Custom error handling that runs before the default handler, and prevents the default handler from handling this
+			return Logger.HandlerResult.Sink
+		end)
+		logger:debug("This is a debug message")
+		logger:info("This is an info message")
+		logger:warning("This is a warning message")
+		logger:error("This is an error message")
+		logger:assert(false, "This is an assertion error")
 
-	Author: Unknown
-	Date: Unknown
+	
 --]]
 
-export type LogLevel = {
-	Debug: number,
-	Info: number,
-	Warning: number,
-	Error: number,
-}
-
-export type HandlerResult = {
-	Sink: "Sink",
-	Continue: "Continue",
-}
-local HandlerResult: HandlerResult = table.freeze({
-	Sink = "Sink",
-	Continue = "Continue",
+export type LogLevel = "Error" | "Warning" | "Info" | "Debug"
+local LogLevel: { [string]: LogLevel } = table.freeze({
+	Debug = "Debug" :: "Debug",
+	Info = "Info" :: "Info",
+	Warning = "Warning" :: "Warning",
+	Error = "Error" :: "Error",
 })
+
+export type HandlerResult = "Sink" | "Continue"
+local HandlerResult: { [string]: HandlerResult } = table.freeze({
+	Sink = "Sink" :: "Sink",
+	Continue = "Continue" :: "Continue",
+})
+
+local orderedLogLevels: { LogLevel } = {
+	LogLevel.Error,
+	LogLevel.Warning,
+	LogLevel.Info,
+	LogLevel.Debug,
+}
 
 export type Handler = (level: LogLevel, name: string, ...any?) -> HandlerResult?
 
-local LogLevelNameByValue: { [number]: LogLevel } = table.freeze({
-	[10] = "Debug",
-	[20] = "Info",
-	[30] = "Warning",
-	[40] = "Error",
-})
+-- Returning a negative number means levelA is less than levelB, 0 means they are equal,
+-- and a positive number means levelA is greater than levelB
+local function compareLevels(levelA: LogLevel, levelB: LogLevel): number
+	return table.find(orderedLogLevels, levelB) :: number - table.find(orderedLogLevels, levelA) :: number
+end
 
-local LogLevel: { [LogLevel]: number } = table.freeze({
-	Debug = 10,
-	Info = 20,
-	Warning = 30,
-	Error = 40,
-})
+local Logger = {}
+Logger.LogLevel = LogLevel
+Logger.HandlerResult = HandlerResult
+Logger.__index = Logger
 
 export type ClassType = typeof(setmetatable(
 	{} :: {
 		name: string,
-		_handlers: { [LogLevel]: { Handler } },
+		_handlersByLevel: { [LogLevel]: { Handler } },
+		_minimumLevel: LogLevel,
 	},
 	Logger
 ))
 
-local Logger = {}
-Logger.LogLevel = LogLevel
-Logger.LogLevelNameByValue = LogLevelNameByValue
-Logger.HandlerResult = HandlerResult
-Logger.__index = Logger
-
-function Logger.new(name: string, level: LogLevel?): ClassType
+function Logger.new(name: string, minimumLevel: LogLevel?): ClassType
 	local self = {
 		name = name,
 		_handlersByLevel = {},
-		_sortedHandlerLevels = {},
-		_level = level or LogLevel.Info,
+		_minimumLevel = minimumLevel or LogLevel.Info,
 	}
 	setmetatable(self, Logger)
 
@@ -84,58 +87,49 @@ function Logger.new(name: string, level: LogLevel?): ClassType
 end
 
 function Logger.addDefaultHandler(self: ClassType)
-	self:addHandler(0, function(level: LogLevel, name: string, ...: any?)
-		local levelName = LogLevelNameByValue[level] or level
-		if level < LogLevel.Warning then
-			print(`{name}:{levelName}:`, ...)
-		elseif level < LogLevel.Error then
-			warn(`{name}:{levelName}:`, ...)
+	self:addHandler(LogLevel.Debug, function(level: LogLevel, name: string, ...: any?)
+		if level == LogLevel.Debug or level == LogLevel.Info then
+			print(`{name}:{level}:`, ...)
+		elseif level == LogLevel.Warning then
+			warn(`{name}:{level}:`, ...)
+		elseif level == LogLevel.Error then
+			error(`{name}:{level}: {...}`, 4)
 		else
-			error(`{name}:{levelName}: {...}`, 4)
+			error(`Invalid log level: {level}`)
 		end
+
+		return HandlerResult.Continue
 	end)
 end
 
-function Logger.addHandler(self: ClassType, level: LogLevel, handler: Handler)
-	if not self._handlersByLevel[level] then
-		self._handlersByLevel[level] = {}
+function Logger.addHandler(self: ClassType, minimumLevel: LogLevel, handler: Handler)
+	if not self._handlersByLevel[minimumLevel] then
+		self._handlersByLevel[minimumLevel] = {}
 	end
 
-	table.insert(self._handlersByLevel[level], 1, handler)
-
-	local handlerLevels = {}
-	for handlerLevel in self._handlersByLevel do
-		if handlerLevel > level then
-			continue
-		end
-
-		table.insert(handlerLevels, handlerLevel)
-	end
-
-	table.sort(handlerLevels, function(a: LogLevel, b: LogLevel)
-		return a > b
-	end)
-
-	self._sortedHandlerLevels = handlerLevels
+	-- Insert at the beginning of the list so newer handlers are processed first (LIFO)
+	table.insert(self._handlersByLevel[minimumLevel], 1, handler)
 end
 
 function Logger._log(self: ClassType, level: LogLevel, ...: any?)
-	if level < self._level then
+	if compareLevels(level, self._minimumLevel) < 0 then
+		-- Log level is lower than the minimum logger level, so we ignore it
 		return
 	end
 
-	local filteredHandlerLevels = {}
-
-	for handlerLevel in self._handlersByLevel do
-		if handlerLevel > level then
+	for _, minimumHandlerLevel: LogLevel in orderedLogLevels do
+		if compareLevels(level, minimumHandlerLevel) < 0 then
+			-- Log level is lower than the minimum handler level, so we ignore it
 			continue
 		end
 
-		table.insert(filteredHandlerLevels, handlerLevel)
-	end
+		local handlers = self._handlersByLevel[minimumHandlerLevel]
 
-	for _, handlerLevel in self._sortedHandlerLevels do
-		local handlers = self._handlersByLevel[handlerLevel]
+		if not handlers then
+			-- No handlers for this level
+			continue
+		end
+
 		for _, handler in handlers do
 			local result = handler(level, self.name, ...)
 			if result == HandlerResult.Sink then
@@ -154,7 +148,7 @@ function Logger.debug(self: ClassType, ...: any?)
 end
 
 function Logger.info(self: ClassType, ...: any?)
-	self:l_logog(LogLevel.Info, ...)
+	self:_log(LogLevel.Info, ...)
 end
 
 function Logger.warning(self: ClassType, ...: any?)
@@ -167,8 +161,7 @@ end
 
 function Logger.assert(self: ClassType, condition: boolean, message: string?, level: LogLevel?)
 	if not condition then
-		level = level or LogLevel.Error
-		self:_log(level, message)
+		self:_log(level or LogLevel.Error, message or "Assertion failed")
 	end
 end
 

--- a/src/StateMachine/Modules/Logger.luau
+++ b/src/StateMachine/Modules/Logger.luau
@@ -1,0 +1,154 @@
+--!strict
+
+--[[
+	TODO: Write header comment and generally document the behavior of this logger
+--]]
+
+export type LogLevel = {
+	Debug: number,
+	Info: number,
+	Warning: number,
+	Error: number,
+}
+
+export type Handler = (level: LogLevel, name: string, ...any?) -> ()
+
+local LogLevelNameByValue: { [number]: LogLevel } = table.freeze({
+	[10] = "Debug",
+	[20] = "Info",
+	[30] = "Warning",
+	[40] = "Error",
+})
+
+local LogLevel: { [LogLevel]: number } = table.freeze({
+	Debug = 10,
+	Info = 20,
+	Warning = 30,
+	Error = 40,
+})
+
+export type HandlerResult = {
+	Sink: "Sink",
+	Continue: "Continue",
+}
+local HandlerResult: HandlerResult = table.freeze({
+	Sink = "Sink",
+	Continue = "Continue",
+})
+
+export type ClassType = typeof(setmetatable(
+	{} :: {
+		name: string,
+		_handlers: { [LogLevel]: { Handler } },
+	},
+	Logger
+))
+
+local Logger = {}
+Logger.LogLevel = LogLevel
+Logger.LogLevelNameByValue = LogLevelNameByValue
+Logger.HandlerResult = HandlerResult
+Logger.__index = Logger
+
+function Logger.new(name: string, level: LogLevel?): ClassType
+	local self = {
+		name = name,
+		_handlersByLevel = {},
+		_sortedHandlerLevels = {},
+		_level = level or LogLevel.Info,
+	}
+	setmetatable(self, Logger)
+
+	return self
+end
+
+function Logger.addDefaultHandler(self: ClassType)
+	self:addHandler(0, function(level: LogLevel, name: string, ...: any?)
+		local levelName = LogLevelNameByValue[level] or level
+		if level < LogLevel.Warning then
+			print(`{name}:{levelName}:`, ...)
+		elseif level < LogLevel.Error then
+			warn(`{name}:{levelName}:`, ...)
+		else
+			error(`{name}:{levelName}: {...}`, 4)
+		end
+	end)
+end
+
+function Logger.addHandler(self: ClassType, level: LogLevel, handler: Handler)
+	if not self._handlersByLevel[level] then
+		self._handlersByLevel[level] = {}
+	end
+
+	table.insert(self._handlersByLevel[level], 1, handler)
+
+	local handlerLevels = {}
+	for handlerLevel in self._handlersByLevel do
+		if handlerLevel > level then
+			continue
+		end
+
+		table.insert(handlerLevels, handlerLevel)
+	end
+
+	table.sort(handlerLevels, function(a: LogLevel, b: LogLevel)
+		return a > b
+	end)
+
+	self._sortedHandlerLevels = handlerLevels
+end
+
+function Logger._log(self: ClassType, level: LogLevel, ...: any?)
+	if level < self._level then
+		return
+	end
+
+	local filteredHandlerLevels = {}
+
+	for handlerLevel in self._handlersByLevel do
+		if handlerLevel > level then
+			continue
+		end
+
+		table.insert(filteredHandlerLevels, handlerLevel)
+	end
+
+	for _, handlerLevel in self._sortedHandlerLevels do
+		local handlers = self._handlersByLevel[handlerLevel]
+		for _, handler in handlers do
+			local result = handler(level, self.name, ...)
+			if result == HandlerResult.Sink then
+				return
+			end
+		end
+	end
+end
+
+function Logger.log(self: ClassType, level: LogLevel, ...: any?)
+	self:_log(level, ...)
+end
+
+function Logger.debug(self: ClassType, ...: any?)
+	self:_log(LogLevel.Debug, ...)
+end
+
+function Logger.info(self: ClassType, ...: any?)
+	self:l_logog(LogLevel.Info, ...)
+end
+
+function Logger.warning(self: ClassType, ...: any?)
+	self:_log(LogLevel.Warning, ...)
+end
+
+function Logger.error(self: ClassType, ...: any?)
+	self:_log(LogLevel.Error, ...)
+end
+
+function Logger.assert(self: ClassType, condition: boolean, message: string?, level: LogLevel?)
+	if not condition then
+		level = level or LogLevel.Error
+		self:_log(level, message)
+	end
+end
+
+return Logger

--- a/src/StateMachine/Modules/Logger.luau
+++ b/src/StateMachine/Modules/Logger.luau
@@ -61,7 +61,12 @@ export type Handler = (level: LogLevel, name: string, ...any?) -> HandlerResult?
 -- Returning a negative number means levelA is less than levelB, 0 means they are equal,
 -- and a positive number means levelA is greater than levelB
 local function compareLevels(levelA: LogLevel, levelB: LogLevel): number
-	return table.find(orderedLogLevels, levelB) :: number - table.find(orderedLogLevels, levelA) :: number
+	local indexA = table.find(orderedLogLevels, levelA)
+	assert(indexA, `Invalid log level: {levelA}`)
+
+	local indexB = table.find(orderedLogLevels, levelB)
+	assert(indexB, `Invalid log level: {levelB}`)
+	return indexB - indexA
 end
 
 local Logger = {}

--- a/src/StateMachine/Modules/Logger.luau
+++ b/src/StateMachine/Modules/Logger.luau
@@ -1,7 +1,28 @@
 --!strict
 
 --[[
-	TODO: Write header comment and generally document the behavior of this logger
+	TODO: Finish writing header comment and generally document the behavior of this logger
+	A lightweight, strongly-typed logger class designed with a minimal set of requirements for the StateMachine project, so it is not feature rich.
+	This logger class includes a few features such as different log levels (Debug, Info, Warning, Error), handler results (Sink, Continue), and the ability to add handlers.
+	It also provides methods for logging at different levels, and an assert method for condition checking where failing the assertion is automatically passed to the appropriate handler.
+
+	Handlers are processed in the opposite order they are added (LIFO). If a handler returns 'Sink', no other handlers will be invoked for that record.
+
+	Adding a default handler pipes non-erroneous records to output via print or warn depending on level,
+	and processes errors by throwing them, which will halt the execution of the program unless caught by an error handling mechanism.
+
+	Usage:
+	local logger = Logger.new("name")
+	logger:addHandler(level, handler)
+	logger:log(level, ...)
+	logger:debug(...)
+	logger:info(...)
+	logger:warning(...)
+	logger:error(...)
+	logger:assert(condition, message, level)
+
+	Author: Unknown
+	Date: Unknown
 --]]
 
 export type LogLevel = {
@@ -11,7 +32,16 @@ export type LogLevel = {
 	Error: number,
 }
 
-export type Handler = (level: LogLevel, name: string, ...any?) -> ()
+export type HandlerResult = {
+	Sink: "Sink",
+	Continue: "Continue",
+}
+local HandlerResult: HandlerResult = table.freeze({
+	Sink = "Sink",
+	Continue = "Continue",
+})
+
+export type Handler = (level: LogLevel, name: string, ...any?) -> HandlerResult?
 
 local LogLevelNameByValue: { [number]: LogLevel } = table.freeze({
 	[10] = "Debug",
@@ -25,15 +55,6 @@ local LogLevel: { [LogLevel]: number } = table.freeze({
 	Info = 20,
 	Warning = 30,
 	Error = 40,
-})
-
-export type HandlerResult = {
-	Sink: "Sink",
-	Continue: "Continue",
-}
-local HandlerResult: HandlerResult = table.freeze({
-	Sink = "Sink",
-	Continue = "Continue",
 })
 
 export type ClassType = typeof(setmetatable(

--- a/src/StateMachine/Modules/Logger.luau
+++ b/src/StateMachine/Modules/Logger.luau
@@ -8,6 +8,7 @@
 	- The ability to add handlers: Handlers are functions that process logs. They can be added to the logger to customize its behavior.
 	- Handler results (Sink, Continue): Handlers return a result which determines if the logger should proceed with processing the log in other handlers.
 	- An assert method: Checks a condition, where failing the assertion invokes the appropriate handlers.
+	- A wrap method: Wraps a callback in pcall, invoking the appropriate handlers if an error occurs.
 
 	Handlers are processed from highest minimum level to lowest minimum level. Within a level, they are processed in the
 	opposite order that they are added (LIFO). If a handler returns 'Sink', no other handlers will be invoked for that record.
@@ -29,6 +30,9 @@
 		logger:warning("This is a warning message")
 		logger:error("This is an error message")
 		logger:assert(false, "This is an assertion error")
+		logger:wrap(function()
+			error("This is an error thrown from a wrapped function")
+		end)
 
 	A primary purpose of this class existing is to be able to check for errors from within tests. The StateMachine queues events,
 	starting a new thread to process them, which means errors that occur are not propagated to the main thread and can't be tested for.
@@ -171,6 +175,15 @@ function Logger.assert(self: ClassType, condition: boolean, message: string?, le
 	if not condition then
 		self:_log(level or LogLevel.Error, message or "Assertion failed")
 	end
+end
+
+function Logger.wrap(self: ClassType, callback: () -> ...any, ...: any?)
+	local success, result = pcall(callback, ...)
+	-- Not using self:assert to ensure the stack trace level is consistent for error tracebacks
+	if not success then
+		self:_log(LogLevel.Error, result)
+	end
+	return success, result
 end
 
 return Logger

--- a/src/StateMachine/init.luau
+++ b/src/StateMachine/init.luau
@@ -110,6 +110,7 @@
 
 local Signal = require(script.Modules.Signal)
 local ThreadQueue = require(script.Modules.ThreadQueue)
+local Logger = require(script.Modules.Logger)
 local t = require(script.Dependencies.t)
 
 -- These types are added for readability to disambiguate what the string is meant to represent in types
@@ -166,14 +167,21 @@ export type ClassType = typeof(setmetatable(
 		_eventQueue: ThreadQueue.ClassType,
 		_handlersByEventName: { [EventName]: EventHandler },
 		_validEventNamesByState: { [State]: { EventName } },
-		_isDebugEnabled: boolean,
+		_logger: Logger.ClassType,
 		_isDestroyed: boolean,
 	},
 	StateMachine
 ))
 
+local machineNumber = 0
+
 local newCheck = t.strict(t.tuple(State, t.map(EventName, Event)))
 function StateMachine.new(initialState: State, eventsByName: { [EventName]: Event }): ClassType
+	machineNumber += 1
+
+	local logger = Logger.new(`Machine{machineNumber}`, Logger.LogLevel.Info)
+	logger:addDefaultHandler()
+
 	newCheck(initialState, eventsByName)
 
 	local self = {
@@ -189,7 +197,7 @@ function StateMachine.new(initialState: State, eventsByName: { [EventName]: Even
 		_eventQueue = ThreadQueue.new(),
 		_handlersByEventName = {} :: { [EventName]: EventHandler },
 		_validEventNamesByState = {} :: { [State]: { EventName } },
-		_isDebugEnabled = false,
+		_logger = logger,
 		_isDestroyed = false,
 	}
 
@@ -209,7 +217,7 @@ function StateMachine._createEventHandlers(self: ClassType, eventsByName: { [Eve
 	for eventName, event in pairs(eventsByName) do
 		self._handlersByEventName[eventName] = function(...: any?)
 			local success, errorMessage = self:_queueEventAsync(eventName, event, ...)
-			assert(success, `Failed to queue event {eventName}: {errorMessage}`)
+			self:getLogger():assert(success, `Failed to queue event {eventName}:\n\t{errorMessage}`)
 		end
 
 		for state, _ in pairs(event.from) do
@@ -245,13 +253,13 @@ function StateMachine._queueEventAsync(self: ClassType, eventName: EventName, ev
 
 		checkAfterState(afterState)
 
-		self:_log(`Transitioning from {beforeState} to {afterState}`)
+		self:getLogger():debug(`Transitioning from {beforeState} to {afterState}`)
 
 		if afterState ~= beforeState then
 			self.leavingState:Fire(beforeState, afterState)
 			self._currentState = afterState
 			self.stateEntered:Fire(afterState, beforeState)
-			self:_log("Valid events:", self:getValidEvents())
+			self:getLogger():debug("Valid events:", self:getValidEvents())
 		end
 
 		if transition.afterAsync then
@@ -266,12 +274,12 @@ function StateMachine._queueEventAsync(self: ClassType, eventName: EventName, ev
 		local isFinished = not afterState
 
 		if isFinished then
-			assert(
+			self:getLogger():assert(
 				event.canBeFinal,
 				`Transition did not return next state during a non-final event {eventName} with state {beforeState}`
 			)
 			-- State machine finished
-			self:_log("Finished")
+			self:getLogger():debug("Finished")
 			self.finished:Fire(beforeState)
 		end
 	end)
@@ -283,13 +291,18 @@ end
 local handleCheck = t.strict(EventName)
 function StateMachine.handle(self: ClassType, eventName: EventName, ...: any?)
 	handleCheck(eventName)
-	assert(not self._isDestroyed, `Attempt to handle event {eventName} after the state machine was destroyed`)
+	self:getLogger()
+		:assert(not self._isDestroyed, `Attempt to handle event {eventName} after the state machine was destroyed`)
 
 	local handleEvent = self._handlersByEventName[eventName] :: EventHandler?
-	assert(handleEvent, `Invalid event name passed to handle: {eventName}`)
+	self:getLogger():assert(handleEvent, `Invalid event name passed to handle: {eventName}`)
 
-	self:_log(`Handling {eventName}`)
+	self:getLogger():debug(`Handling {eventName}`)
 	coroutine.wrap(handleEvent)(...)
+end
+
+function StateMachine.getLogger(self: ClassType)
+	return self._logger
 end
 
 function StateMachine.getState(self: ClassType)
@@ -298,18 +311,6 @@ end
 
 function StateMachine.getValidEvents(self: ClassType)
 	return self._currentState and self._validEventNamesByState[self._currentState] or {}
-end
-
-local setDebugEnabledCheck = t.strict(t.boolean)
-function StateMachine.setDebugEnabled(self: ClassType, isEnabled: boolean)
-	setDebugEnabledCheck(isEnabled)
-	self._isDebugEnabled = isEnabled
-end
-
-function StateMachine._log(self: ClassType, ...: any)
-	if self._isDebugEnabled then
-		print(...)
-	end
 end
 
 function StateMachine.destroy(self: ClassType)

--- a/src/StateMachine/init.luau
+++ b/src/StateMachine/init.luau
@@ -105,7 +105,7 @@
 
 			light:handle(Event.SwitchOff) -- prints "Light is transitioning to Off"
 			light:handle(Event.SwitchOn) -- prints "Light is transitioning to On", increases brightness over time, and then prints "Light is now On"
-			light:handle(Event.SwitchOn) -- warns "Illegal event `SwitchOn` called during state `On`" with a stack trace
+			light:handle(Event.SwitchOn) -- errors "Illegal event `SwitchOn` called during state `On`" with a stack trace
 --]]
 
 local Signal = require(script.Modules.Signal)
@@ -150,7 +150,10 @@ local Event = t.strictInterface({
 -- EventHandlers fire signals and call transition callbacks as outlined in the header comment
 type EventHandler = (...any) -> ()
 
+local DEFAULT_LOG_LEVEL = Logger.LogLevel.Info
+
 local StateMachine = {}
+StateMachine.Logger = Logger
 StateMachine.__index = StateMachine
 
 export type ClassType = typeof(setmetatable(
@@ -175,14 +178,22 @@ export type ClassType = typeof(setmetatable(
 
 local machineNumber = 0
 
-local newCheck = t.strict(t.tuple(State, t.map(EventName, Event)))
-function StateMachine.new(initialState: State, eventsByName: { [EventName]: Event }): ClassType
+local newCheck =
+	t.strict(t.tuple(State, t.map(EventName, Event), t.optional(t.string), t.optional(t.valueOf(Logger.LogLevel))))
+function StateMachine.new(
+	initialState: State,
+	eventsByName: { [EventName]: Event },
+	name: string?,
+	logLevel: Logger.LogLevel?
+): ClassType
+	newCheck(initialState, eventsByName, name, logLevel)
+
 	machineNumber += 1
+	local defaultName = `Machine{machineNumber}`
+	name = name or `Machine{machineNumber}`
 
-	local logger = Logger.new(`Machine{machineNumber}`, Logger.LogLevel.Info)
+	local logger = Logger.new(name or defaultName, logLevel or DEFAULT_LOG_LEVEL)
 	logger:addDefaultHandler()
-
-	newCheck(initialState, eventsByName)
 
 	local self = {
 		-- Public events

--- a/src/StateMachine/init.luau
+++ b/src/StateMachine/init.luau
@@ -223,7 +223,7 @@ local createEventHandlersCheck = t.strictInterface({
 	[EventName] = Event,
 })
 function StateMachine._createEventHandlers(self: ClassType, eventsByName: { [EventName]: Event })
-	createEventHandlersCheck(eventsByName)
+	self:getLogger():wrap(createEventHandlersCheck, eventsByName)
 
 	for eventName, event in pairs(eventsByName) do
 		self._handlersByEventName[eventName] = function(...: any?)
@@ -241,7 +241,7 @@ end
 local checkAfterState = t.strict(t.optional(State))
 local queueEventAsyncCheck = t.strict(t.tuple(EventName, Event))
 function StateMachine._queueEventAsync(self: ClassType, eventName: EventName, event: Event, ...: any?)
-	queueEventAsyncCheck(eventName, event)
+	self:getLogger():wrap(queueEventAsyncCheck, eventName, event)
 
 	local args = { ... }
 
@@ -262,7 +262,7 @@ function StateMachine._queueEventAsync(self: ClassType, eventName: EventName, ev
 			return
 		end
 
-		checkAfterState(afterState)
+		self:getLogger():wrap(checkAfterState, afterState)
 
 		self:getLogger():debug(`Transitioning from {beforeState} to {afterState}`)
 
@@ -301,7 +301,7 @@ end
 -- VarArgs get passed to the transition callbacks
 local handleCheck = t.strict(EventName)
 function StateMachine.handle(self: ClassType, eventName: EventName, ...: any?)
-	handleCheck(eventName)
+	self:getLogger():wrap(handleCheck, eventName)
 	self:getLogger()
 		:assert(not self._isDestroyed, `Attempt to handle event {eventName} after the state machine was destroyed`)
 


### PR DESCRIPTION
Testing for presence of errors was difficult because the state machine queues up events on new threads, so the errors don't propagate back to the test thread. To be able to test for errors then, I added this logger class to route errors through, with the added utility of being able to easily set log levels to show in the output and hook into log processing from anywhere. This also lets you add a name to your state machine instance that is attached to the logs so you know which machine is erroring if you have multiple.