### PR TITLE
Bump tools to latest versions as of 9/11/2024

### DIFF
--- a/.luau-lsp.json
+++ b/.luau-lsp.json
@@ -1,7 +1,7 @@
 {
   "luau-lsp.require.mode": "relativeToFile",
   "luau-lsp.require.directoryAliases": {
-    "@lune/": "~/.lune/.typedefs/0.8.6/"
+    "@lune/": "~/.lune/.typedefs/0.8.8/"
   },
   "luau-lsp.ignoreGlobs": ["**/_Index/**", "globalTypes.d.lua", "*Packages/**"],
   "luau-lsp.types.roblox": true

--- a/.vscode/settings.json.example
+++ b/.vscode/settings.json.example
@@ -1,7 +1,7 @@
 {
   "luau-lsp.require.mode": "relativeToFile",
   "luau-lsp.require.directoryAliases": {
-    "@lune/": "~/.lune/.typedefs/0.8.4/"
+    "@lune/": "~/.lune/.typedefs/0.8.8/"
   },
   "luau-lsp.sourcemap.rojoProjectFile": "test.project.json",
   "luau-lsp.ignoreGlobs": [

--- a/aftman.toml
+++ b/aftman.toml
@@ -3,9 +3,9 @@
 
 # To add a new tool, add an entry to this table.
 [tools]
-rojo = "rojo-rbx/rojo@7.4.1"
+rojo = "rojo-rbx/rojo@7.4.4"
 selene = "Kampfkarren/selene@0.27.1"
 stylua = "JohnnyMorganz/stylua@0.20.0"
 wally = "UpliftGames/wally@0.3.2"
-lune = "lune-org/lune@0.8.6"
-luau-lsp = "JohnnyMorganz/luau-lsp@1.32.0"
+lune = "lune-org/lune@0.8.8"
+luau-lsp = "JohnnyMorganz/luau-lsp@1.32.4"


### PR DESCRIPTION
Updates all tools to latest versions as of 9/11/2024. All operations in `lune run ci` still function.