### PR TITLE
Switch aftman to rokit, improve contributing docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.7
 
-      - name: Install Aftman
-        uses: ok-nick/setup-aftman@v0.4.2
+      - name: Install Rokit
+        uses: CompeyDev/setup-rokit@v0.1.2
 
       - name: Setup Lune
         run: lune setup
@@ -28,13 +28,13 @@ jobs:
         uses: actions/cache@v4.0.2
         with:
           path: |
-            ~/.aftman
+            ~/.rokit
             ~/.lune
             Packages
             DevPackages
-          key: tools-${{ hashFiles('aftman.toml') }}
+          key: tools-${{ hashFiles('rokit.toml') }}
 
-  # Kampfkarren/selene is assumed to be included in the repository's aftman.toml file
+  # Kampfkarren/selene is assumed to be included in the repository's rokit.toml file
   linting:
     name: Lint with Selene
     runs-on: ubuntu-latest
@@ -48,11 +48,11 @@ jobs:
         uses: actions/cache@v4.0.2
         with:
           path: |
-            ~/.aftman
+            ~/.rokit
             ~/.lune
             Packages
             DevPackages
-          key: tools-${{ hashFiles('aftman.toml') }}
+          key: tools-${{ hashFiles('rokit.toml') }}
 
       - name: Lint StateMachine
         run: ./scripts/lint.sh src/StateMachine
@@ -63,7 +63,7 @@ jobs:
       - name: Lint Lune
         run: ./scripts/lint.sh lune
 
-  # JohnnyMorganz/stylua is assumed to be included in the repository's aftman.toml file
+  # JohnnyMorganz/stylua is assumed to be included in the repository's rokit.toml file
   formatting:
     name: Check format with StyLua
     runs-on: ubuntu-latest
@@ -77,11 +77,11 @@ jobs:
         uses: actions/cache@v4.0.2
         with:
           path: |
-            ~/.aftman
+            ~/.rokit
             ~/.lune
             Packages
             DevPackages
-          key: tools-${{ hashFiles('aftman.toml') }}
+          key: tools-${{ hashFiles('rokit.toml') }}
 
       - name: Enforce StateMachine code style with StyLua
         run: ./scripts/formatCheck.sh src/StateMachine
@@ -92,7 +92,7 @@ jobs:
       - name: Enforce Lune scripts code style with StyLua
         run: ./scripts/formatCheck.sh lune
 
-  # JohnnyMorganz/luau-lsp is assumed to be included in the repository's aftman.toml file
+  # JohnnyMorganz/luau-lsp is assumed to be included in the repository's rokit.toml file
   analyzing:
     name: Analyze with luau-lsp
     runs-on: ubuntu-latest
@@ -106,11 +106,11 @@ jobs:
         uses: actions/cache@v4.0.2
         with:
           path: |
-            ~/.aftman
+            ~/.rokit
             ~/.lune
             Packages
             DevPackages
-          key: tools-${{ hashFiles('aftman.toml') }}
+          key: tools-${{ hashFiles('rokit.toml') }}
 
       - name: Analyze StateMachine with luau-lsp
         run: |
@@ -125,7 +125,7 @@ jobs:
       - name: Analyze Lune scripts with luau-lsp
         run: ./scripts/analyze.sh lune
 
-  # lune-org/lune is assumed to be included in the repository's aftman.toml file
+  # lune-org/lune is assumed to be included in the repository's rokit.toml file
   testing:
     name: Run jest tests with Lune
     runs-on: ubuntu-latest
@@ -139,11 +139,11 @@ jobs:
         uses: actions/cache@v4.0.2
         with:
           path: |
-            ~/.aftman
+            ~/.rokit
             ~/.lune
             Packages
             DevPackages
-          key: tools-${{ hashFiles('aftman.toml') }}
+          key: tools-${{ hashFiles('rokit.toml') }}
 
       - name: Test with Lune
         run: ./scripts/test.sh

--- a/.vscode/settings.json.example
+++ b/.vscode/settings.json.example
@@ -9,5 +9,5 @@
     "**/*.d.luau",
     "*Packages/**"
   ],
-  "cSpell.words": ["aftman", "rbxl", "rojo"]
+  "cSpell.words": ["rokit", "rbxl", "rojo"]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,24 +17,41 @@ This project does _not_ use submodules, so it can be cloned with either of the f
 
 ## Install tools
 
-Various tools used by the project are installed with [Aftman](https://github.com/LPGhatguy/aftman), a toolchain manager.
+Various tools used by the project are installed with [Rokit](https://github.com/rojo-rbx/rokit), a toolchain manager.
 
-1. Download and install Aftman from the [Aftman releases page](https://github.com/LPGhatguy/aftman/releases/latest) on your system.
-1. Run `aftman install` in the repository directory. This installs tools from `aftman.toml` and adds them to your system environment path variable so you can use the tools in the command line.
+1. Download and install Rokit by following the instructions on the [Rokit readme](https://github.com/rojo-rbx/rokit?tab=readme-ov-file#installation).
+1. Run the following command in the repository directory:
 
-Additionally, if you're using VS Code it's recommended to install the [Luau Language Server plugin by Johnny Morganz](https://github.com/JohnnyMorganz/luau-lsp). If you use this plugin, be sure to disable other conflicting plugins you might have such as Roblox LSP by Nightrains.
+```bash
+rokit install
+```
+
+This installs tools from `rokit.toml` and adds them to your system environment path variable so you can use the tools in the command line.
+
+Additionally, if you're using VS Code it's recommended to install the following extensions:
+
+- [johnnymorganz.luau-lsp](https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.luau-lsp)
+- [johnnymorganz.stylua](https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.stylua)
+- [kampfkarren.selene-vscode](https://marketplace.visualstudio.com/items?itemName=Kampfkarren.selene-vscode)
+- [streetsidesoftware.code-spell-checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)
+> [!TIP]
+> You should be automatically prompted to install these plugins when opening the project in VS Code because they're listed in [extensions.json](.vscode/extensions.json)
+
+> [!IMPORTANT]  
+> If you use luau-lsp as a language server, be sure to disable other conflicting plugins you might have such as Roblox LSP by Nightrains.
 
 ### Tools in use
 
-The following tools are installed by Aftman:
+The following tools are installed by Rokit:
 
-| Tool                                | Description                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Rojo** for building               | This project uses [Rojo](https://rojo.space/) to build from source files to a Roblox binary. You can either use the command line version installed by Aftman, or [install the VS Code extension](https://marketplace.visualstudio.com/items?itemName=evaera.vscode-rojo) for a handy user interface for building and serving the project. See [Building the Project](#build-the-project) for details on using Rojo in this project. |
-| **Selene** for linting              | This project also uses [selene](https://kampfkarren.github.io/selene/roblox.html) for [linting](https://owasp.org/www-project-devsecops-guideline/latest/01b-Linting-Code).                                                                                                                                                                                                                                                         |
-| **StyLua** for formatting           | This project's Luau code base is formatted with [StyLua](https://github.com/JohnnyMorganz/StyLua). You can either use the command line version installed by Aftman, or [install the VS Code extension](https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.stylua)                                                                                                                                                    |
-| **Wally** for package management    | This project uses [Wally](https://wally.run/) to fetch open source dependency packages. See [Installing Packages](#install-packages) for instructions on using this command line tool.                                                                                                                                                                                                                                              |
-| **Lune** for running tests from cli | This project uses [Lune](https://lune-org.github.io/docs) to run tests from the command line. See [Run tests](#run-tests) for instructions on using this command line tool.                                                                                                                                                                                                                                      |
+| Tool                                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Rojo** for building                       | This project uses [Rojo](https://rojo.space/) to build from source files to a Roblox binary. You can either use the command line version installed by Rokit (recommended), or [install the VS Code extension](https://marketplace.visualstudio.com/items?itemName=evaera.vscode-rojo) for a handy user interface for building and serving the project. See [Building the Project](#build-the-project) for details on using Rojo in this project. |
+| **Selene** for linting                      | This project also uses [selene](https://kampfkarren.github.io/selene/roblox.html) for [linting](https://owasp.org/www-project-devsecops-guideline/latest/01b-Linting-Code). You can either use the command line version installed by Rokit, or [install the VS Code extension](https://marketplace.visualstudio.com/items?itemName=Kampfkarren.selene-vscode) to have it constantly running in the background.                                  |
+| **StyLua** for formatting                   | This project's Luau code base is formatted with [StyLua](https://github.com/JohnnyMorganz/StyLua). You can either use the command line version installed by Rokit, or [install the VS Code extension](https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.stylua)                                                                                                                                                                 |
+| **Luau LSP** for analysis & language server | This project uses [Luau Language Server](https://github.com/JohnnyMorganz/luau-lsp) to run analysis on luau code as a ci step. While the tool is also a standalone language server, the recommended flow is to also [install the VS Code extension](https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.luau-lsp) to have it constantly running in the background.                                                                 |
+| **Wally** for package management            | This project uses [Wally](https://wally.run/) to fetch open source dependency packages. See [Installing Packages](#install-packages) for instructions on using this command line tool.                                                                                                                                                                                                                                                          |
+| **Lune** for running tests from cli         | This project uses [Lune](https://lune-org.github.io/docs) to run tests from the command line. See [Run tests](#run-tests) for instructions on using this command line tool.                                                                                                                                                                                                                                                                     |
 
 ## Install packages
 
@@ -65,8 +82,12 @@ The following packages are installed as dev dependencies:
 
 Lune provides type definitions and documentation, but has to be configured for your editor. To do so, do the following steps (source: [Lune Editor Setup](https://lune-org.github.io/docs/getting-started/4-editor-setup))
 
-1. Run `lune setup`
-1. Modify your editor settings. For VS Code, open `settings.json` and verify it contains the following:
+Run the command:
+```bash
+lune setup
+```
+
+Then, modify your editor settings. For VS Code, open [`settings.json`](./.vscode/settings.json) and verify it contains the following:
 
 ```json
 "luau-lsp.require.mode": "relativeToFile",
@@ -75,31 +96,39 @@ Lune provides type definitions and documentation, but has to be configured for y
 }
 ```
 
-An example `settings.json` file is provided (see `.vscode/settings.json.example`), which also contains setup for the `luau-lsp` plugin to use `test.project.json`.
+An example [`settings.json`](./.vscode/settings.json) file is provided (see [`settings.json.example`](./.vscode/settings.json.example)), which also contains setup for the `luau-lsp` plugin to use [`test.project.json`](./test.project.json).
 
 ## Build the project
 
 Rojo builds from json files that map files on your file system to locations in the roblox data model. This project includes two project.json files:
 
-| File                   | Purpose                                                                                                                                                                                                                             |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `default.project.json` | The distributable consumer build in the form of a single ModuleScript and its children. This defines the structure when a consumer links this project into their `project.json` file.                                                 |
-| `test.project.json`    | Useful for developing this project, because it defines an entire place file that can be opened and synced rather than just the ModuleScript. This is the one you should build and serve with Rojo during development of this project. |
+| File                   | Purpose                                                                                                                                                                                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`default.project.json`](./default.project.json) | The distributable consumer build in the form of a single ModuleScript and its children. This defines the structure when a consumer links this project into their `project.json` file.                                                 |
+| [`test.project.json`](./test.project.json)       | Useful for developing this project, because it defines an entire place file that can be opened and synced rather than just the ModuleScript. This is the one you should build and serve with Rojo during development of this project. |
 
 If you plan to [run tests](#run-tests) from CLI (recommended), the test runner script automatically builds before running tests. You don't need to build it yourself.
 
-If you're running tests in studio yourself (not recommended) instead of using the CLI, you can do an initial project build with either of the following:
+<details>
+<summary>
+If you're running tests in studio yourself (not recommended) instead of using the CLI, you can do an initial project build by expanding this section and doing either of the following:
+</summary>
 
 | Method        | Instructions                                                                                                                                           |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | CLI           | `rojo build test.project.json -o StateMachine-Test.rbxl`                                                                                               |
 | VSC Extension | Click Rojo on the status bar at the bottom, mouse over `test.project.json` in the pop-up menu, and click the Build icon on the right of the list item. |
+</details>
 
 ## Sync file changes to studio
 
-IF YOU ARE RUNNING TESTS USING THE COMMAND LINE INTERFACE (RECOMMENDED), THEN SKIP THIS SECTION! Go directly to [Run tests](#run-tests). You don't need to sync files to studio because you build the project before each test run.
+> [!TIP]
+> IF YOU ARE RUNNING TESTS USING THE COMMAND LINE INTERFACE (RECOMMENDED), THEN SKIP THIS SECTION! Go directly to [Run tests](#run-tests). You don't need to sync files to studio because you build the project before each test run.
 
-However, if you are manually running tests in studio (not recommended), you need to sync changes after the initial build. Proceed with the following steps.
+<details>
+<summary>
+However, if you are manually running tests in studio (not recommended), you need to sync changes after the initial build. Expand this section and proceed with the following steps.
+</summary>
 
 ### Install the Rojo plugin for Roblox Studio plugin
 
@@ -141,6 +170,7 @@ This instructions to flip this flag differ on Mac vs Windows.
 * **For Windows users:** see [this devforum post](https://devforum.roblox.com/t/how-to-return-altenter-to-its-prior-functionality/997206)
 
 You need to set the `FFlagEnableLoadModule` value to `true`. Be sure to restart Roblox Studio after flipping the flag.
+</details>
 
 ### Run tests
 

--- a/lune/ci.luau
+++ b/lune/ci.luau
@@ -29,7 +29,7 @@ local mainThread = coroutine.running()
 
 local function runLuneCommand(command: string)
 	local root = process.env.HOME or process.env.USERPROFILE
-	local lunePath = Path.join(root, ".aftman", "bin", "lune")
+	local lunePath = Path.join(root, ".rokit", "bin", "lune")
 	local proc = process.spawn(lunePath, { "run", command })
 
 	print(proc.stdout)

--- a/lune/formatFix.luau
+++ b/lune/formatFix.luau
@@ -30,7 +30,7 @@ local mainThread = coroutine.running()
 
 local function fixFormatForPath(path: string)
 	local root = process.env.HOME or process.env.USERPROFILE
-	local styluaPath = Path.join(root, ".aftman", "bin", "stylua")
+	local styluaPath = Path.join(root, ".rokit", "bin", "stylua")
 	local proc = process.spawn(styluaPath, { path })
 
 	print(proc.stdout)

--- a/lune/test.luau
+++ b/lune/test.luau
@@ -52,7 +52,7 @@ local function buildProject(rojoProjectFilePath: string)
 	local rojoProject = readRojoProject(rojoProjectFilePath)
 	local builtProjectFilePath = `{rojoProject.name}.rbxl`
 	local root = process.env.HOME or process.env.USERPROFILE
-	local rojoPath = Path.join(root, ".aftman", "bin", "rojo")
+	local rojoPath = Path.join(root, ".rokit", "bin", "rojo")
 
 	print(`Building project {rojoProjectFilePath} into {builtProjectFilePath} with Rojo...\n`)
 	local proc = process.spawn(rojoPath, { "build", rojoProjectFilePath, "--output", builtProjectFilePath })

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,4 +1,4 @@
-# This file lists tools managed by Aftman, a cross-platform toolchain manager.
+# This file lists tools managed by Rokit, a cross-platform toolchain manager.
 # For more information, see https://github.com/LPGhatguy/aftman
 
 # To add a new tool, add an entry to this table.
@@ -6,6 +6,6 @@
 rojo = "rojo-rbx/rojo@7.4.4"
 selene = "Kampfkarren/selene@0.27.1"
 stylua = "JohnnyMorganz/stylua@0.20.0"
+luau-lsp = "JohnnyMorganz/luau-lsp@1.32.4"
 wally = "UpliftGames/wally@0.3.2"
 lune = "lune-org/lune@0.8.8"
-luau-lsp = "JohnnyMorganz/luau-lsp@1.32.4"

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,5 +1,5 @@
 # This file lists tools managed by Rokit, a cross-platform toolchain manager.
-# For more information, see https://github.com/LPGhatguy/aftman
+# For more information, see https://github.com/rojo-rbx/rokit
 
 # To add a new tool, add an entry to this table.
 [tools]

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -13,7 +13,7 @@ fi
 
 if [ -n "$2" ]; then
     echo "Beginning analysis on $2 with sourcemap from $1, settings from $SETTINGS_FILE, and global types from $TYPES_FILE..."
-    $HOME/.aftman/bin/luau-lsp analyze \
+    $HOME/.rokit/bin/luau-lsp analyze \
         --settings=$SETTINGS_FILE \
         --definitions=$TYPES_FILE \
         --sourcemap "$1" \
@@ -22,7 +22,7 @@ if [ -n "$2" ]; then
     echo "Analysis of $2 complete!"
 else
     echo "Beginning analysis on $1 with settings from $SETTINGS_FILE and global types from $TYPES_FILE..."
-    $HOME/.aftman/bin/luau-lsp analyze \
+    $HOME/.rokit/bin/luau-lsp analyze \
         --settings=$SETTINGS_FILE \
         --definitions=$TYPES_FILE \
         --ignore "*Packages/**" \

--- a/scripts/formatCheck.sh
+++ b/scripts/formatCheck.sh
@@ -4,6 +4,6 @@ set -e
 
 echo "Beginning format check on $1..."
 
-$HOME/.aftman/bin/stylua --check $1
+$HOME/.rokit/bin/stylua --check $1
 
 echo "Format check on $1 complete!"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,6 +4,6 @@ set -e
 
 echo "Beginning linting on $1..."
 
-$HOME/.aftman/bin/selene $1
+$HOME/.rokit/bin/selene $1
 
 echo "Linting $1 complete!"

--- a/scripts/sourcemap.sh
+++ b/scripts/sourcemap.sh
@@ -4,6 +4,6 @@ set -e
 
 echo "Creating sourcemap from $1 to $2..."
 
-$HOME/.aftman/bin/rojo sourcemap $1 --output $2
+$HOME/.rokit/bin/rojo sourcemap $1 --output $2
 
 echo "Sourcemap $2 created!"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,6 +4,6 @@ set -e
 
 echo "Starting test runner..."
 
-$HOME/.aftman/bin/lune run test
+$HOME/.rokit/bin/lune run test
 
 echo "Test runner complete!"


### PR DESCRIPTION
Rokit is a more forward looking toolchain manager than Aftman. See [this section of Rokit's readme](https://github.com/rojo-rbx/rokit?tab=readme-ov-file#for-everyone-else) for justification.

Updated CONTRIBUTING.md to reflect this, and revised it to make it a little easier to parse by making the commands stand out more consistently, moving tips into highlighted areas, and collapsing non-recommended steps.