### PR TITLE
Fix Wally publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,8 +161,11 @@ jobs:
       - name: Add rokit tools to PATH
         run: echo "$HOME/.rokit/bin" >> $GITHUB_PATH
 
+      - name: Log in to Wally
+        run: wally login --token ${{ secrets.WALLY_ACCESS_TOKEN }}
+
       - name: Publish package to Wally
-        run: wally publish --token ${{ secrets.WALLY_ACCESS_TOKEN }}
+        run: wally publish
 
   upload-github-artifacts:
     name: Upload artifacts to the GitHub release


### PR DESCRIPTION
There's an error in the wally publish workflow:
> error: Found argument '--token' which wasn't expected, or it isn't valid in this context

Wally's docs are wrong, --token isn't supported for publish apparently. This PR separates the login to a separate step.