### PR TITLE
Attempt fix release preprocessor step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,21 @@ jobs:
     name: Preprocess release (update versions, copyright years)
     runs-on: ubuntu-latest
     needs: [install-tools, get-version]
+    environment: Release Preprocessor
     permissions:
       contents: write
 
     steps:
+      - uses: actions/create-github-app-token@v1.7.0
+        id: release-preprocessor-bot-token
+        with:
+          app-id: ${{ vars.RELEASE_PREPROCESSOR_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PREPROCESSOR_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4.1.7
+        with:
+          token: ${{ steps.release-preprocessor-bot-token.outputs.token }}
 
       - name: Restore installed items
         uses: actions/cache@v4.0.2


### PR DESCRIPTION
There's a permissions issue with the release preprocessing step where it can't commit the changes back to `main` because the branch is protected. This PR adds a GitHub bot token and key during checkout to hopefully give it the necessary permissions (I've granted this app access to bypass it in the repo settings).

The variables are restricted to an environment which only applies to the main branch in order to avoid them being used to bypass the protections by anyone. That means I also won't be able to test if this works until after I merge this PR, so I will likely need another follow-up PR to fix any bugs.