### PR TITLE
Ensure wally publish step checks out the latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.7
+        with:
+          ref: ${{ github.ref }}
 
       - name: Restore installed items
         uses: actions/cache@v4.0.2
@@ -148,6 +150,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.7
+        with:
+          ref: ${{ github.ref }}
 
       - name: Restore installed items
         uses: actions/cache@v4.0.2


### PR DESCRIPTION
Since the release action makes commits and tries to checkout again after those commits, it was missing the recent commits in the second checkout because by default the checkout action uses the ref of the event that triggered the action. 

This PR ensures it checks out latest instead of the outdated version, so that the wally.toml will contain the updated version when it tries to publish.