### PR TITLE
Fix wally package structure

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -8,6 +8,7 @@ realm = "shared"
 registry = "https://github.com/UpliftGames/wally-index"
 exclude = ["*"]
 include = [
+    "src",
     "src/StateQ",
     "src/StateQ/**",
     "default.project.json",


### PR DESCRIPTION
Currently, the published Wally packages are missing the StateQ folder despite being included in `wally.toml` because the `exclude *` is excluding the `src` folder, which overrides the inclusion of subfolders of `src`. 

This PR adds `src` to include, so that the `src/StateQ` and `src/StateQ/**` actually get included. This means `src/TestService` will still be excluded as intended because `src/**` is not included.