### PR TITLE
Fix outdated GitHub actions always failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   install-tools:
     name: Install tools and dependencies
@@ -13,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
 
       - name: Install Rokit
-        uses: CompeyDev/setup-rokit@v0.1.2
+        uses: CompeyDev/setup-rokit@v0.2.1
 
       - name: Setup Lune
         run: lune setup
@@ -25,7 +28,7 @@ jobs:
         run: wally install
 
       - name: Cache installed items
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.rokit
@@ -42,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
 
       - name: Restore installed items
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.rokit
@@ -71,10 +74,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
 
       - name: Restore installed items
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.rokit
@@ -100,10 +103,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
 
       - name: Restore installed items
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.rokit
@@ -133,10 +136,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
 
       - name: Restore installed items
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.rokit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   get-version:
     name: Get version from release tag
@@ -16,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
 
       - name: Output version and tag name
         id: output-version
@@ -42,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
 
       - name: Install Rokit
-        uses: CompeyDev/setup-rokit@v0.1.2
+        uses: CompeyDev/setup-rokit@v0.2.1
 
       - name: Setup Lune
         run: lune setup
@@ -54,7 +57,7 @@ jobs:
         run: wally install
 
       - name: Cache installed items
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.rokit
@@ -81,12 +84,12 @@ jobs:
           private-key: ${{ secrets.RELEASE_PREPROCESSOR_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
         with:
           token: ${{ steps.release-preprocessor-bot-token.outputs.token }}
 
       - name: Restore installed items
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.rokit
@@ -116,12 +119,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ needs.preprocess-release.outputs.commit-hash }}
 
       - name: Restore installed items
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.rokit
@@ -137,7 +140,7 @@ jobs:
         run: lune run build ${{ needs.get-version.outputs.version-with-dashes }}
 
       - name: Cache artifacts
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             build
@@ -152,12 +155,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ needs.preprocess-release.outputs.commit-hash }}
 
       - name: Restore installed items
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             ~/.rokit
@@ -167,7 +170,7 @@ jobs:
           key: tools-${{ hashFiles('rokit.toml') }}
 
       - name: Restore build artifacts
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             build
@@ -192,7 +195,7 @@ jobs:
 
     steps:
       - name: Restore build artifacts
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v5.0.5
         with:
           path: |
             build

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -6,8 +6,9 @@ TYPES_FILE=globalTypes.d.luau
 SETTINGS_FILE=.luau-lsp.json
 
 if [ ! -f "$TYPES_FILE" ]; then
-    echo "Fetching global types..."
-    curl https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/main/scripts/globalTypes.d.luau > $TYPES_FILE
+    LUAU_LSP_VERSION=$(grep 'luau-lsp' rokit.toml | sed 's/.*@//')
+    echo "Fetching global types for luau-lsp $LUAU_LSP_VERSION..."
+    curl -L "https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/$LUAU_LSP_VERSION/scripts/globalTypes.d.luau" > $TYPES_FILE
     echo "Wrote global types to $TYPES_FILE"
 fi
 

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -6,9 +6,9 @@ TYPES_FILE=globalTypes.d.luau
 SETTINGS_FILE=.luau-lsp.json
 
 if [ ! -f "$TYPES_FILE" ]; then
-    LUAU_LSP_VERSION=$(grep 'luau-lsp' rokit.toml | sed 's/.*@//')
+    LUAU_LSP_VERSION=$(grep '^luau-lsp' rokit.toml | sed -E 's/.*@([0-9.]+)".*/\1/')
     echo "Fetching global types for luau-lsp $LUAU_LSP_VERSION..."
-    curl -L "https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/$LUAU_LSP_VERSION/scripts/globalTypes.d.luau" > $TYPES_FILE
+    curl -fL "https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/$LUAU_LSP_VERSION/scripts/globalTypes.d.luau" > "$TYPES_FILE"
     echo "Wrote global types to $TYPES_FILE"
 fi
 


### PR DESCRIPTION
Bump actions versions; cache is too old and no longer runs. It fails with this error:
>  Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v4.0.2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

It's a good time to update them all.