### PR TITLE
Add max queue size parameter, accessors, improve docs, remove unused dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## STOP
 
-If you just want to use the final product, this readme is not for you. This readme is related contributing to the project, not using it.
+If you just want to use the final product, this readme is not for you. This readme is related to contributing to the project, not using it.
 
 If you have questions, bugs, feature requests, or feedback, please [open an issue](https://github.com/BusyCityGuy/finite-state-machine-luau/issues)!
 
@@ -74,10 +74,10 @@ The following package is installed as a production dependency:
 
 The following packages are installed as dev dependencies:
 
-| Package                           | Description                                                                                                                                                                                                                                            |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Jest** for testing              | This project uses [Jest](https://jsdotlua.github.io/jest-lua/) to run tests on the state machine project to ensure accuracy and catch bugs during development. See [Running Tests](#run-tests) for instructions on how to run these tests.             |
-| **Freeze** for table manipulation | This project uses [Freeze](https://duckarmor.github.io/Freeze/) to simplify manipulation of tables to make tests more concise and easier to understand.                                                                                                |
+| Package                        | Description                                                                                                                                                                                                                                |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Jest** for testing           | This project uses [Jest](https://jsdotlua.github.io/jest-lua/) to run tests on the state machine project to ensure accuracy and catch bugs during development. See [Run tests](#run-tests) for instructions on how to run these tests.     |
+| **JestGlobals** for test setup | Test files import Jest globals such as `describe`, `it`, and `expect` from this companion package.                                                                                                                                         |
 
 ## Set up Lune for your editor
 
@@ -176,7 +176,7 @@ If you're running tests in Lune from the CLI, you don't need to worry about this
 
 However, running tests in Roblox Studio requires flipping the `FFlagEnableLoadModule` flag to get access to this function. (Track the issue [here](https://github.com/jsdotlua/jest-lua/issues/3))
 
-This instructions to flip this flag differ on Mac vs Windows.
+The instructions to flip this flag differ on Mac vs Windows.
 
 - **For Mac users:** see [this issue](https://github.com/jsdotlua/jest-lua/issues/6).
 - **For Windows users:** see [this devforum post](https://devforum.roblox.com/t/how-to-return-altenter-to-its-prior-functionality/997206)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ An intuitive fully-typed Finite State Machine in [Luau](https://luau-lang.org/) 
 
 This project is licensed under the terms of the MIT license. See [LICENSE.md](https://github.com/busycityguy/finite-state-machine-luau/blob/main/LICENSE.md) for details.
 
-## This project is a work in progress
-
-Tests need to be written and the API may receive small changes while this project is being finalized for a first release.
-
 # What's a finite state machine?
 
 A Finite State Machine (FSM) provides a way to enforce specific logical flow among a set of States. Given an Event, the FSM responds by looking up the corresponding Transition for that Event in its current State. A Transition is a callback function that is invoked when an Event is given to the FSM, and it returns the next State for the FSM to move to.
@@ -28,9 +24,11 @@ These signals, transition callbacks, and state changes are processed in the foll
     - with the VarArgs from `:handle(eventName, transitionArgs...)`
 1. Fire `leavingState` signal
     - with arguments `beforeState, afterState`
-1. Update `_currentState` to next state
+    - skipped when the next state equals the current state
+1. Update the current state when it changed
 1. Fire `stateEntered` signal
     - with arguments `afterState, beforeState`
+    - skipped when the next state equals the current state
 1. Call `transition.afterAsync()` (if specified)
     - with the VarArgs from `:handle(eventName, transitionArgs...)`
 1. Fire `afterEvent` signal
@@ -40,8 +38,10 @@ These signals, transition callbacks, and state changes are processed in the foll
 
 Transitions can be asynchronous, which is supported by queuing each Event submitted via :handle() and processing them in First-In-First-Out (FIFO) order. The next Event starts processing immediately after the previous Event's handler fires `afterEvent`.
 
+The optional `maxQueueLength` constructor parameter bounds how many Events may be queued at once. When the queue is full, further :handle() calls fail with a `queue`-phase EventError. When omitted, the queue is unbounded.
+
 The FSM can Finish if a Transition does not return a "next state" during an event marked as "canBeFinal".
-In such a case, the FSM will fire a `finished` event and will error if any further Events are handled.
+In such a case, the FSM will fire the `finished` signal and will error if any further Events are handled.
 A `nil` state means the FSM has Finished.
 
 # Example usage
@@ -105,6 +105,32 @@ light:handle(Event.SwitchOn) -- prints "Light is transitioning to On", increases
 light:handle(Event.SwitchOn) -- errors asynchronously via `eventErrored` (illegal event for the current state); see Error handling below
 ```
 
+## Constructor
+
+You'll probably only ever need the first two constructor parameters, but there are a few more optionally available.
+
+`StateQ.new(initialState, eventsByName, name?, isDebugEnabled?, maxQueueLength?)`
+
+| Parameter          | Type                  | Description                                                                                                                                                                                |
+| ------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `initialState`     | `string`              | The state the machine starts in.                                                                                                                                                           |
+| `eventsByName`     | `{ [string]: Event }` | The events the machine can handle and their transitions.                                                                                                                                   |
+| `name`             | `string?`             | A name used in `eventErrored` payloads and debug output. Defaults to an auto-generated `Machine{n}`.                                                                                       |
+| `isDebugEnabled`   | `boolean?`            | When `true`, the machine prints debug output. Defaults to `false`.                                                                                                                         |
+| `maxQueueLength`   | `number?`             | A positive number bounding how many events may be queued at once. When omitted, the queue is unbounded. Handling an event while the queue is full fails with a `queue`-phase `EventError`. |
+
+## Accessors
+
+| Method                | Returns      | Description                                                 |
+|-----------------------|--------------|-------------------------------------------------------------|
+| `getState()`          | `string?`    | The current state, or `nil` if the machine has finished.    |
+| `getValidEvents()`    | `{ string }` | The event names that are valid in the current state.        |
+| `getName()`           | `string`     | The machine's name.                                         |
+| `getMaxQueueLength()` | `number`     | The configured queue capacity (`math.huge` when unbounded). |
+| `isFinished()`        | `boolean`    | Whether the machine has finished (its state is `nil`).      |
+| `isDestroyed()`       | `boolean`    | Whether `destroy()` has been called.                        |
+| `isDebugEnabled()`    | `boolean`    | Whether debug output is enabled.                            |
+
 # Error handling
 
 Every call to `:handle()` enqueues the event for processing on a background thread and returns immediately. Failures fall into two categories depending on when they occur.
@@ -139,6 +165,7 @@ These occur later, on the queue thread, while the event is actually being proces
 - An event is processed after the machine has finished
 - A non-final event's transition returns `nil`
 - A transition returns a value that fails the state type check
+- The event queue is at capacity (`maxQueueLength` exceeded)
 
 Listen for them when you want to log, recover, or assert in tests:
 
@@ -190,8 +217,8 @@ machine.eventErrored:Connect(function(_errorInfo) end)
 
 If your project is set up to build with Rojo, the preferred installation method is using [Wally](https://wally.run/). Add this to your `wally.toml` file:
 
-```bash
-> StateQ = "busycityguy/stateq@0.0.7"
+```toml
+StateQ = "busycityguy/stateq@0.0.7"
 ```
 
 If you're not using Wally, you can add this repository as a submodule of your project by running the following command:

--- a/src/StateQ/Modules/ThreadQueue.luau
+++ b/src/StateQ/Modules/ThreadQueue.luau
@@ -43,7 +43,7 @@ function ThreadQueue.new(timeBetween: number?, maxQueueLength: number?, enableCo
 end
 
 function ThreadQueue.submitAsync(self: ClassType, callback: Callback): (boolean, string?)
-	if #self._queue > self._maxQueueLength then
+	if #self._queue >= self._maxQueueLength then
 		return false, string.format("Queue is at capacity (%i)", self._maxQueueLength)
 	end
 

--- a/src/StateQ/Modules/ThreadQueue.luau
+++ b/src/StateQ/Modules/ThreadQueue.luau
@@ -63,6 +63,10 @@ function ThreadQueue.getLength(self: ClassType): number
 	return #self._queue
 end
 
+function ThreadQueue.getMaxQueueLength(self: ClassType): number
+	return self._maxQueueLength
+end
+
 function ThreadQueue.skipToLastEnqueued(self: ClassType)
 	-- This method will not skip currently executing requests, but will remove
 	-- all pending requests from the queue aside from the most recently enqueued

--- a/src/StateQ/init.luau
+++ b/src/StateQ/init.luau
@@ -59,6 +59,9 @@
 
 		Transitions can be asynchronous, which is supported by queuing each Event submitted via :handle() and processing them in First-In-First-Out (FIFO) order. The next Event starts processing immediately after the previous Event's handler fires `afterEvent`.
 
+		The optional `maxQueueLength` constructor parameter bounds how many Events may be queued at once. When the queue is full,
+		further :handle() calls fail with a `queue`-phase EventError. When omitted, the queue is unbounded.
+
 		The FSM can Finish if a Transition does not return a "next state" during an event marked as "canBeFinal".
 		In such a case, the FSM will fire a `finished` event and will error if any further Events are handled.
 		A `nil` state means the FSM has Finished.
@@ -175,7 +178,9 @@ export type EventError = {
 }
 
 -- Runtime type check definitions are up here because it somehow messes up Luau typing if they're put right above the corresponding function.
-local newCheck = t.strict(t.tuple(State, t.map(EventName, Event), t.optional(t.string), t.optional(t.boolean)))
+local newCheck = t.strict(
+	t.tuple(State, t.map(EventName, Event), t.optional(t.string), t.optional(t.boolean), t.optional(t.numberPositive))
+)
 local createEventHandlersCheck = t.strictInterface({
 	[EventName] = Event,
 })
@@ -230,9 +235,10 @@ function StateQ.new(
 	initialState: State,
 	eventsByName: { [EventName]: Event },
 	name: string?,
-	isDebugEnabled: boolean?
+	isDebugEnabled: boolean?,
+	maxQueueLength: number?
 ): ClassType
-	newCheck(initialState, eventsByName, name, isDebugEnabled)
+	newCheck(initialState, eventsByName, name, isDebugEnabled, maxQueueLength)
 
 	machineNumber += 1
 
@@ -248,7 +254,7 @@ function StateQ.new(
 		-- Private properties
 		_name = name or `Machine{machineNumber}`,
 		_currentState = initialState :: State?,
-		_eventQueue = ThreadQueue.new(),
+		_eventQueue = ThreadQueue.new(nil, maxQueueLength),
 		_handlersByEventName = {} :: { [EventName]: EventHandler },
 		_validEventNamesByState = {} :: { [State]: { EventName } },
 		_isDebugEnabled = isDebugEnabled or false,

--- a/src/StateQ/init.luau
+++ b/src/StateQ/init.luau
@@ -44,9 +44,11 @@
 			* with the VarArgs from `:handle(eventName, transitionArgs...)`
 		3. Fire `leavingState` signal
 			* with arguments `beforeState, afterState`
-		4. Update `_currentState` to next state
+			* skipped when the next state equals the current state
+		4. Update the current state when it changed
 		5. Fire `stateEntered` signal
 			* with arguments `afterState, beforeState`
+			* skipped when the next state equals the current state
 		6. Call `transition.afterAsync()` (if specified)
 			* with the VarArgs from `:handle(eventName, transitionArgs...)`
 		7. Fire `afterEvent` signal
@@ -63,7 +65,7 @@
 		further :handle() calls fail with a `queue`-phase EventError. When omitted, the queue is unbounded.
 
 		The FSM can Finish if a Transition does not return a "next state" during an event marked as "canBeFinal".
-		In such a case, the FSM will fire a `finished` event and will error if any further Events are handled.
+		In such a case, the FSM will fire the `finished` signal and will error if any further Events are handled.
 		A `nil` state means the FSM has Finished.
 
 	# Example usage
@@ -113,7 +115,7 @@
 
 			light:handle(Event.SwitchOff) -- prints "Light is transitioning to Off"
 			light:handle(Event.SwitchOn) -- prints "Light is transitioning to On", increases brightness over time, and then prints "Light is now On"
-			light:handle(Event.SwitchOn) -- errors "Illegal event `SwitchOn` called during state `On`" with a stack trace
+			light:handle(Event.SwitchOn) -- errors asynchronously via `eventErrored` (illegal event for the current state)
 --]]
 
 -- This module should be in a folder called Packages that contains other module dependencies.
@@ -134,8 +136,8 @@ type EventName = string
 local EventName = t.string
 
 -- Transitions are sets of functions that handle Events based on the Machine's current state.
--- First, the `before` callback executes which returns the next State to transition to, or `nil` if the machine is meant to finish.
--- Second, an optional `after` callback can be defined that that executes after the machine finishes transitioning states.
+-- First, `beforeAsync` returns the next State to transition to, or `nil` when the event is marked `canBeFinal`.
+-- Second, an optional `afterAsync` callback executes after the machine finishes transitioning states.
 -- Both callbacks can be asynchronous, and the signals described in the header comment will be delayed according to these functions yielding.
 export type Transition = {
 	beforeAsync: (...any) -> State?,
@@ -486,6 +488,26 @@ end
 
 function StateQ.getValidEvents(self: ClassType)
 	return self._currentState and self._validEventNamesByState[self._currentState] or {}
+end
+
+function StateQ.getName(self: ClassType): string
+	return self._name
+end
+
+function StateQ.isDestroyed(self: ClassType): boolean
+	return self._isDestroyed
+end
+
+function StateQ.isFinished(self: ClassType): boolean
+	return self._currentState == nil
+end
+
+function StateQ.isDebugEnabled(self: ClassType): boolean
+	return self._isDebugEnabled
+end
+
+function StateQ.getMaxQueueLength(self: ClassType): number
+	return self._eventQueue:getMaxQueueLength()
 end
 
 function StateQ.destroy(self: ClassType)

--- a/wally.lock
+++ b/wally.lock
@@ -4,13 +4,8 @@ registry = "test"
 
 [[package]]
 name = "busycityguy/stateq"
-version = "0.0.6"
-dependencies = [["t", "osyrisrblx/t@3.1.1"], ["Freeze", "duckarmor/freeze@0.1.4"], ["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest-globals@3.10.0"]]
-
-[[package]]
-name = "duckarmor/freeze"
-version = "0.1.4"
-dependencies = [["TestEZ", "roblox/testez@0.4.1"]]
+version = "0.0.7"
+dependencies = [["t", "osyrisrblx/t@3.1.1"], ["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest-globals@3.10.0"]]
 
 [[package]]
 name = "jsdotlua/boolean"
@@ -255,9 +250,4 @@ dependencies = [["collections", "jsdotlua/collections@1.2.7"]]
 [[package]]
 name = "osyrisrblx/t"
 version = "3.1.1"
-dependencies = []
-
-[[package]]
-name = "roblox/testez"
-version = "0.4.1"
 dependencies = []

--- a/wally.toml
+++ b/wally.toml
@@ -21,6 +21,5 @@ include = [
 t = "osyrisrblx/t@3.1.1"
 
 [dev-dependencies]
-Freeze = "duckarmor/freeze@0.1.4"
 Jest = "jsdotlua/jest@3.10.0"
 JestGlobals = "jsdotlua/jest-globals@3.10.0"


### PR DESCRIPTION
ThreadQueue already supports a max queue size. I don't know of any use case to expose it as a feature of state machine, but I figure I may as well anyway. It also had an off-by-one issue with the max size check that is fixed here.

In preparation for writing tests, accessors will avoid having to directly read private fields, so I'm adding a bunch of them.

These new api members need to be documented, so I added them and took the liberty to make a few other (small) docs touch-ups.

Finally, Freeze isn't actually used, especially now that we have `table.freeze`, I can remove this.

After this PR, I should be ready to write some nice tests using these accessors and the recently-added error observability!